### PR TITLE
Setup initial configuration file spec for solver

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+output-file = flake8_log.txt
+tee = True
+ignore = E722,E203,W503,T001

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,3 @@
 max-line-length = 100
 output-file = flake8_log.txt
 tee = True
-ignore = E722,E203,W503,T001

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -1,0 +1,105 @@
+"""main.py
+
+The main configuration module containing base settings pydantic
+classes
+"""
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+from pydantic import BaseSettings, BaseModel, Field
+from pydantic.fields import ModelField
+
+import yaml
+
+from .solver import Solver
+
+CONFIG_FILE = "config.yaml"
+
+def yaml_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
+    """
+    Read config settings form a local yaml file where the software runs
+
+    Parameters
+    ----------
+    settings : pydantic.BaseSettings
+        The base settings class
+
+    Returns
+    -------
+    dict
+        The configuration dictionary based on inputs from the yaml
+        file
+    """
+    encoding = settings.__config__.env_file_encoding
+    config_path = Path(CONFIG_FILE)
+    if config_path.exists():
+        # Only load config.yaml when it exists
+        return yaml.safe_load(config_path.read_text(encoding))
+    return {} 
+
+class BaseConfiguration(BaseSettings):
+    """Base configuration class"""
+    @classmethod
+    def add_fields(cls, **field_definitions: Any) -> None:
+        """
+        Adds additional configuration field on the fly (inplace)
+
+        Parameters
+        ----------
+        **field_definitions
+            Keyword arguments of the new field to be added
+        """
+        new_fields: Dict[str, ModelField] = {}
+        new_annotations: Dict[str, Optional[type]] = {}
+
+        for f_name, f_def in field_definitions.items():
+            if isinstance(f_def, tuple):
+                try:
+                    f_annotation, f_value = f_def
+                except ValueError as e:
+                    raise Exception(
+                        'field definitions should either be a tuple of (<type>, <default>) or just a '
+                        'default value, unfortunately this means tuples as '
+                        'default values are not allowed'
+                    ) from e
+            else:
+                f_annotation, f_value = None, f_def
+
+            if f_annotation:
+                new_annotations[f_name] = f_annotation
+
+            new_fields[f_name] = ModelField.infer(name=f_name, value=f_value, annotation=f_annotation, class_validators=None, config=cls.__config__)
+
+        cls.__fields__.update(new_fields)
+        cls.__annotations__.update(new_annotations)
+
+    class Config:
+        env_file_encoding = 'utf-8'
+        env_nested_delimiter = '__'
+        env_prefix = 'seagap_'
+
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings,
+            env_settings,
+            file_secret_settings,
+        ):
+            return (
+                init_settings,
+                yaml_config_settings_source,
+                env_settings,
+                file_secret_settings,
+            )
+
+
+class Configuration(BaseConfiguration):
+    """Configuration class to generate config object"""
+    site_id: str = Field(
+        ...,
+        description="The site identification for processing"
+    )
+    # TODO: Separate settings out to core plugin
+    solver: Optional[Solver] = Field(
+        None,
+        description="Solver configurations"
+    )

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -5,6 +5,7 @@ classes
 """
 from pathlib import Path
 from typing import Any, Dict, Optional
+import warnings
 
 import yaml
 from pydantic import BaseSettings, Field
@@ -35,6 +36,13 @@ def yaml_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     if config_path.exists():
         # Only load config.yaml when it exists
         return yaml.safe_load(config_path.read_text(encoding))
+    else:
+        warnings.warn(
+            (
+                f"Configuration file `{CONFIG_FILE}` not found. "
+                "Will attempt to retrieve configuration from environment variables."
+            )
+        )
     return {}
 
 

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -4,15 +4,16 @@ The main configuration module containing base settings pydantic
 classes
 """
 from pathlib import Path
-from typing import List, Optional, Dict, Any
-from pydantic import BaseSettings, BaseModel, Field
-from pydantic.fields import ModelField
+from typing import Any, Dict, Optional
 
 import yaml
+from pydantic import BaseSettings, Field
+from pydantic.fields import ModelField
 
 from .solver import Solver
 
 CONFIG_FILE = "config.yaml"
+
 
 def yaml_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     """
@@ -34,10 +35,12 @@ def yaml_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     if config_path.exists():
         # Only load config.yaml when it exists
         return yaml.safe_load(config_path.read_text(encoding))
-    return {} 
+    return {}
+
 
 class BaseConfiguration(BaseSettings):
     """Base configuration class"""
+
     @classmethod
     def add_fields(cls, **field_definitions: Any) -> None:
         """
@@ -57,9 +60,10 @@ class BaseConfiguration(BaseSettings):
                     f_annotation, f_value = f_def
                 except ValueError as e:
                     raise Exception(
-                        'field definitions should either be a tuple of (<type>, <default>) or just a '
-                        'default value, unfortunately this means tuples as '
-                        'default values are not allowed'
+                        "field definitions should either be a tuple of"
+                        " (<type>, <default>) or just a "
+                        "default value, unfortunately this means tuples as "
+                        "default values are not allowed"
                     ) from e
             else:
                 f_annotation, f_value = None, f_def
@@ -67,15 +71,21 @@ class BaseConfiguration(BaseSettings):
             if f_annotation:
                 new_annotations[f_name] = f_annotation
 
-            new_fields[f_name] = ModelField.infer(name=f_name, value=f_value, annotation=f_annotation, class_validators=None, config=cls.__config__)
+            new_fields[f_name] = ModelField.infer(
+                name=f_name,
+                value=f_value,
+                annotation=f_annotation,
+                class_validators=None,
+                config=cls.__config__,
+            )
 
         cls.__fields__.update(new_fields)
         cls.__annotations__.update(new_annotations)
 
     class Config:
-        env_file_encoding = 'utf-8'
-        env_nested_delimiter = '__'
-        env_prefix = 'seagap_'
+        env_file_encoding = "utf-8"
+        env_nested_delimiter = "__"
+        env_prefix = "seagap_"
 
         @classmethod
         def customise_sources(
@@ -94,12 +104,7 @@ class BaseConfiguration(BaseSettings):
 
 class Configuration(BaseConfiguration):
     """Configuration class to generate config object"""
-    site_id: str = Field(
-        ...,
-        description="The site identification for processing"
-    )
+
+    site_id: str = Field(..., description="The site identification for processing")
     # TODO: Separate settings out to core plugin
-    solver: Optional[Solver] = Field(
-        None,
-        description="Solver configurations"
-    )
+    solver: Optional[Solver] = Field(None, description="Solver configurations")

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -3,9 +3,9 @@
 The main configuration module containing base settings pydantic
 classes
 """
+import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional
-import warnings
 
 import yaml
 from pydantic import BaseSettings, Field

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -1,0 +1,165 @@
+"""solver.py
+
+The solver module containing base models for
+solver configuration
+"""
+from typing import List, Optional, Dict, Literal, Any
+from uuid import uuid4
+
+from pydantic import BaseModel, validator, PrivateAttr, Field
+
+
+class ReferenceEllipsoid(BaseModel):
+    """Reference ellipsoid base model"""
+    semi_major_axis: float = Field(
+        ...,
+        description="Semi-major axis (m)"
+    )
+    reverse_flattening: float = Field(
+        ...,
+        description="Reverse flattening"
+    )
+    eccentricity: Optional[float] = Field(
+        None,
+        description="Eccentricity. **This field will be computed during object creation**"
+    )
+
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+
+        # Note: Potential improvement with computed value: https://github.com/pydantic/pydantic/pull/2625
+        __pydantic_self__.eccentricity = (
+            2.0 / __pydantic_self__.reverse_flattening - (1.0 / __pydantic_self__.reverse_flattening) ** 2.0
+        )
+
+class ArrayCenter(BaseModel):
+    """Array center base model."""
+    lat: float = Field(
+        ...,
+        description="Latitude"
+    )
+    lon: float = Field(
+        ...,
+        description="Longitude"
+    )
+
+
+class SolverGlobal(BaseModel):
+    """Solver global base model for inversion processs."""
+    max_dat = 45000
+    max_gps = 423000
+    max_del = 15000
+    max_brk = 20
+    max_surv = 10
+    max_sdt_obs = 2000
+    max_obm = 472
+    max_unmm = 9
+
+
+class SolverTransponder(BaseModel):
+    """Solver transponder base model for each transponder configuration"""
+    lat: float = Field(
+        ...,
+        description="Latitude"
+    )
+    lon: float = Field(
+        ...,
+        description="Longitude"
+    )
+    height: float = Field(
+        ...,
+        description="Transponder depth in meters (m)."
+    )
+    internal_delay: float = Field(
+        ...,
+        description="""Transponder internal delay in seconds (s).
+        Assume transponder delay contains:
+        delay-line, non-delay-line internal delays
+        (determined at transdec) and any user set delay (dail-in)."""
+    )
+    sv_mean: float = Field(
+        ...,
+        description="""Sound velocity mean (m/s)."""
+    )
+    pxp_id: Optional[str] = Field(
+        None,
+        description="""Transponder id string.
+        **This field will be computed during object creation**"""
+    )
+    # Auto generated uuid per transponder for unique identifier
+    _uuid: str = PrivateAttr()
+
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+
+        __pydantic_self__._uuid = uuid4().hex
+    
+        # ID is 7 characters based on the uuid
+        __pydantic_self__.pxp_id = __pydantic_self__._uuid[:7]
+
+
+class Solver(BaseModel):
+    """
+    Solver transponder base model containing configurations
+    for GNSS-A inversion computation
+    """
+
+    defaults: SolverGlobal = SolverGlobal()
+    transponders: Optional[List[SolverTransponder]] = Field(
+        ...,
+        description="A list of transponders configurations"
+    )
+    reference_ellipsoid: Optional[ReferenceEllipsoid] = Field(
+        ...,
+        description="Reference ellipsoid configurations"
+    )
+    gps_sigma_limit: float = Field(
+        0.05,
+        description="Maximum positional sigma allowed to use GPS positions"
+    )
+    std_dev: bool = Field(
+        True,
+        description="GPS positional uncertainty flag std. dev. (True) or variance (False)"
+    )
+    geoid_undulation: float = Field(
+        ...,
+        description="Geoid undulation at sea surface point"
+    )
+    # TODO: Separate into different plugin for ray tracing
+    ray_trace_type: Literal["scale", "1d"] = Field(
+        "scale",
+        description="Ray trace method to use"
+    )
+    bisection_tolerance: float = Field(
+        1e-10,
+        description="Tolerance to stop bisection during ray trace"
+    )
+    array_center: ArrayCenter = Field(
+        ...,
+        description="Array center to use for calculation"
+    )
+    travel_times_variance: float = Field(
+        1e-10,
+        description="VARIANCE (s**2) PXP two-way travel time measurement"
+    )
+    # Transponder Wait Time - delay at surface transducer (secs.)
+    # ship/SV3 = 0.0s, WG = 0.1s
+    transponder_wait_time: float = Field(
+        0.0,
+        description="Transponder Wait Time - delay at surface transducer (secs.). Options: ship/SV3 = 0.0s, WG = 0.1s"
+    )
+
+
+    @validator('gps_sigma_limit')
+    def check_sigma_limit(cls, v):
+        """Validate gps sigma limit value"""
+        if (v < 0.0) or (v > 100.0):
+            raise ValueError('GPS Sigma limit must be between 0 - 100')
+        return v
+    
+    @validator('transponder_wait_time')
+    def check_transponder_wait_time(cls, v):
+        """Validate transponder wait time value"""
+        if (v not in [0.0, 0.1]):
+            raise ValueError('Transponder wait time must either be 0.0s or 0.1s')
+        return v

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -63,7 +63,10 @@ class SolverTransponder(BaseModel):
         delay-line, non-delay-line internal delays
         (determined at transdec) and any user set delay (dail-in).""",
     )
-    sv_mean: float = Field(..., description="""Sound velocity mean (m/s).""")
+    sv_mean: Optional[float] = Field(
+        None,
+        description="""Dynamically generated sound velocity mean (m/s)."""
+    )
     pxp_id: Optional[str] = Field(
         None,
         description="""Transponder id string.

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -64,8 +64,7 @@ class SolverTransponder(BaseModel):
         (determined at transdec) and any user set delay (dail-in).""",
     )
     sv_mean: Optional[float] = Field(
-        None,
-        description="""Dynamically generated sound velocity mean (m/s)."""
+        None, description="""Dynamically generated sound velocity mean (m/s)."""
     )
     pxp_id: Optional[str] = Field(
         None,

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -97,7 +97,10 @@ class Solver(BaseModel):
         ..., description="Reference ellipsoid configurations"
     )
     gps_sigma_limit: float = Field(
-        0.05, description="Maximum positional sigma allowed to use GPS positions"
+        0.05,
+        description="Maximum positional sigma allowed to use GPS positions",
+        gt=0,
+        lt=100,
     )
     std_dev: bool = Field(
         True,
@@ -126,13 +129,6 @@ class Solver(BaseModel):
         description="""Transponder Wait Time - delay at surface transducer (secs.).
         Options: ship/SV3 = 0.0s, WG = 0.1s""",
     )
-
-    @validator("gps_sigma_limit")
-    def check_sigma_limit(cls, v):
-        """Validate gps sigma limit value"""
-        if (v < 0.0) or (v > 100.0):
-            raise ValueError("GPS Sigma limit must be between 0 - 100")
-        return v
 
     @validator("transponder_wait_time")
     def check_transponder_wait_time(cls, v):


### PR DESCRIPTION
## Overview

This PR adds configs modules for setting up the main configuration file data validation and settings management.
The fields are based on the original master configuration file. This PR uses [pydantic](https://docs.pydantic.dev/) technology to define the configurations.

@johnbdesanto could you go through the descriptions and ensure that I have the accurate text for the fields? Please focus on the solver configuration. Also, if you have another name for this too, please let me know.

## Original

```
2022-09-28 00:00:00
3
     0    08       45.302064471    -124.978181346   -1176.5866      0.200000d0       1481.551 
     1    12       45.295207747    -124.958752845   -1146.5881      0.320000d0       1481.521 
     2    22       45.309643593    -124.959348875   -1133.7305      0.440000d0       1481.509 
6378137.d0  298.257222101d0   ! ellipsoid parameters  WGS84
0.05d0               ! Maximum GPS positional sigma (m)
0                   ! Input GPS positional uncertainties given as: if std. dev. = 0, if var. = 1
n                   ! Constrain buoy-buoy baselines
y                   ! Hold PXP geometry and orientation fixed
n                   ! Hold PXP baseline lenghts fixed
n                   ! Hold ellipsoid heights constant
n                   ! Constrain PXP to move together vertically
n                   ! Estimate body frame offsets
n                   ! Compute residuals only
0                   ! Correction to tabluated acoustic times (sec.)
-26.59d0           ! Geoid undulation at sea surface point
0                   ! =0 scale factor, =1 1-D ray trace
1.d-10              ! xacc tolerance for ray trace bisection
45.3023d0 -124.9656d0   ! Latitude/Longitude array center (decimal degrees)
1.d-10              ! Variance (s**2) of PXP two-way travel time measurement
0.0d0               ! Transponder Wait Time (seconds); ship/SV3 = 0.0s, WG = 0.1s
```

## Updated sample

```
site_id: NCL1

solver:
  transponders:
    - lat: 45.302064471
      lon: -124.978181346
      height: -1176.5866
      internal_delay: 0.200000
      sv_mean: 1481.551
    - lat: 45.295207747
      lon: -124.958752845
      height: -1146.5881
      internal_delay: 0.320000
      sv_mean: 1481.521
    - lat: 45.309643593
      lon: -124.959348875
      height: -1133.7305
      internal_delay: 0.440000
      sv_mean: 1481.509
  reference_ellipsoid:
    semi_major_axis: 6378137.000
    reverse_flattening: 298.257222101
  gps_sigma_limit: 0.05
  std_dev: true
  geoid_undulation: -26.59
  bisection_tolerance: 1e-10
  array_center:
    lat: 45.3023
    lon: -124.9656
  travel_times_variance: 1e-10
  transponder_wait_time: 0.0

```

## Related issues

- #19 
- #21 