### PR TITLE
Update badge to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <span><img src="https://img.shields.io/badge/SSEC-Project-purple?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic" /><span>
 ![BSD License](https://badgen.net/badge/license/BSD-3-Clause/blue)
-[![Documentation Status](https://readthedocs.org/projects/offshore-geodesy/badge/?version=latest)](https://offshore-geodesy.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/seagap/badge/?version=latest)](https://seagap.readthedocs.io/en/latest/?badge=latest)
 
 Repo for keeping track of various ideas, to-do items, and information for the Offshore Subduction Geodesy Project.
 


### PR DESCRIPTION
## Overview

This PR updates badge to documentation build within ReadTheDocs. The initial jupyterbook docs setup can be found in commit https://github.com/uw-ssec/offshore-geodesy/commit/8f989bb242795ef9b18026db0f5302783342b43e. Additionally, PR https://github.com/uw-ssec/offshore-geodesy/pull/56 updates reference to `offshore-geodesy` to be `seagap` instead. 

## Related issues
- #51