### PR TITLE
Add io utilities and io configurations to YAML spec

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,4 +25,11 @@ jobs:
       env:
         FORCE_COLOR: 3
       run: |
-        pytest -vv -rx tests
+        set -o pipefail
+        pytest -vvv |& tee unit_test_log${{ matrix.python-version }}.log
+    - name: Upload unit test log
+      if: ${{ success() || failure() }}
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: unit_test_log${{ matrix.python-version }}
+        path: unit_test_log${{ matrix.python-version }}.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install project
-      run: pip install ".[all]"
+      run: pip install ".[test]"
     - name: Run unit tests
       env:
         FORCE_COLOR: 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,4 @@ jobs:
       env:
         FORCE_COLOR: 3
       run: |
-        pytest -vv -rx tests |& tee unit_test_log${{ matrix.python-version }}.log
-    - name: Upload unit test log
-      if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v3.1.2
-      with:
-        name: unit_test_log${{ matrix.python-version }}
-        path: unit_test_log${{ matrix.python-version }}.log
+        pytest -vv -rx tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10']
         experimental: [false]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,8 @@ jobs:
     - name: Run unit tests
       env:
         FORCE_COLOR: 3
-      run: pytest -vvv |& tee unit_test_log${{ matrix.python-version }}.log
+      run: |
+        pytest -vv -rx tests |& tee unit_test_log${{ matrix.python-version }}.log
     - name: Upload unit test log
       if: ${{ success() || failure() }}
       uses: actions/upload-artifact@v3.1.2

--- a/seagap/configs/io.py
+++ b/seagap/configs/io.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List, Literal, Optional
+
+import fsspec
+
+from pydantic import BaseModel, Field, PrivateAttr, validator
+
+from ..utilities.io import check_file_exists, check_permission
+
+class InputData(BaseModel):
+    """Input data path specification base model"""
+
+    path: str = Field(
+        ...,
+        description="Path string to the data. Ex. s3://bucket/some_data.dat",
+    )
+    storage_options: Dict[str, Any] = Field(
+        {},
+        description="""Protocol keyword argument for specified file system.
+        This is not needed for local paths""",
+    )
+
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+
+        # Checks the file
+        if not check_file_exists(
+            __pydantic_self__.path, __pydantic_self__.storage_options
+        ):
+            raise FileNotFoundError("The specified file doesn't exist!")
+        
+class OutputPath(BaseModel):
+    """Output path base model."""
+
+    path: str = Field(
+        ...,
+        description="Path string to the output path. Ex. s3://bucket/my_output",
+    )
+    storage_options: Dict[str, Any] = Field(
+        {},
+        description="""Protocol keyword argument for specified file system.
+        This is not needed for local paths""",
+    )
+
+    _fsmap: str = PrivateAttr()
+
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+
+        __pydantic_self__._fsmap = fsspec.get_mapper(
+            __pydantic_self__.path, **__pydantic_self__.storage_options
+        )
+        # Checks the file permission as the object is being created
+        check_permission(__pydantic_self__._fsmap)

--- a/seagap/configs/io.py
+++ b/seagap/configs/io.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict
 
 import fsspec
-from pydantic import BaseModel, Field, PrivateAttr, validator
+
+from pydantic import BaseModel, Field, PrivateAttr
 
 from ..utilities.io import check_file_exists, check_permission
 

--- a/seagap/configs/io.py
+++ b/seagap/configs/io.py
@@ -16,8 +16,10 @@ class InputData(BaseModel):
     )
     storage_options: Dict[str, Any] = Field(
         {},
-        description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths""",
+        description=(
+            "Protocol keyword argument for specified file system. "
+            "This is not needed for local paths"
+        ),
     )
 
     def __init__(__pydantic_self__, **data: Any) -> None:
@@ -39,8 +41,10 @@ class OutputPath(BaseModel):
     )
     storage_options: Dict[str, Any] = Field(
         {},
-        description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths""",
+        description=(
+            "Protocol keyword argument for specified file system. "
+            "This is not needed for local paths"
+        ),
     )
 
     _fsmap: str = PrivateAttr()

--- a/seagap/configs/io.py
+++ b/seagap/configs/io.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict
 
 import fsspec
-
 from pydantic import BaseModel, Field, PrivateAttr
 
 from ..utilities.io import check_file_exists, check_permission

--- a/seagap/configs/io.py
+++ b/seagap/configs/io.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Literal, Optional
 
 import fsspec
-
 from pydantic import BaseModel, Field, PrivateAttr, validator
 
 from ..utilities.io import check_file_exists, check_permission
+
 
 class InputData(BaseModel):
     """Input data path specification base model"""
@@ -27,7 +27,8 @@ class InputData(BaseModel):
             __pydantic_self__.path, __pydantic_self__.storage_options
         ):
             raise FileNotFoundError("The specified file doesn't exist!")
-        
+
+
 class OutputPath(BaseModel):
     """Output path base model."""
 

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -117,7 +117,7 @@ class OutputPath(BaseModel):
 
     path: str = Field(
         ...,
-        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat",
+        description="Path string to the output path. Ex. s3://bucket/my_output",
     )
     storage_options: Dict[str, Any] = Field(
         {},

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -7,12 +7,11 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import fsspec
 import yaml
-from pydantic import BaseModel, BaseSettings, Field, PrivateAttr
+from pydantic import BaseSettings, Field
 from pydantic.fields import ModelField
 
-from ..utilities.io import check_permission
+from .io import OutputPath
 from .solver import Solver
 
 CONFIG_FILE = "config.yaml"
@@ -110,31 +109,6 @@ class BaseConfiguration(BaseSettings):
                 env_settings,
                 file_secret_settings,
             )
-
-
-class OutputPath(BaseModel):
-    """Output path base model."""
-
-    path: str = Field(
-        ...,
-        description="Path string to the output path. Ex. s3://bucket/my_output",
-    )
-    storage_options: Dict[str, Any] = Field(
-        {},
-        description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths""",
-    )
-
-    _fsmap: str = PrivateAttr()
-
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        super().__init__(**data)
-
-        __pydantic_self__._fsmap = fsspec.get_mapper(
-            __pydantic_self__.path, **__pydantic_self__.storage_options
-        )
-        # Checks the file permission as the object is being created
-        check_permission(__pydantic_self__._fsmap)
 
 
 class Configuration(BaseConfiguration):

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 
 import fsspec
 import yaml
-from pydantic import BaseModel, BaseSettings, Field, PrivateAttr, validator
+from pydantic import BaseModel, BaseSettings, Field, PrivateAttr
 from pydantic.fields import ModelField
 
 from ..utilities.io import check_file_permissions

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -7,14 +7,13 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import fsspec
 import yaml
-from pydantic import BaseSettings, Field, BaseModel, validator, PrivateAttr
+from pydantic import BaseModel, BaseSettings, Field, PrivateAttr, validator
 from pydantic.fields import ModelField
 
-import fsspec
-
-from .solver import Solver
 from ..utilities.io import check_file_permissions
+from .solver import Solver
 
 CONFIG_FILE = "config.yaml"
 
@@ -112,17 +111,18 @@ class BaseConfiguration(BaseSettings):
                 file_secret_settings,
             )
 
+
 class OutputPath(BaseModel):
     """Output path base model."""
-    
+
     path: str = Field(
         ...,
-        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat"
+        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat",
     )
     storage_options: Dict[str, Any] = Field(
         {},
         description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths"""
+        This is not needed for local paths""",
     )
 
     _fsmap: str = PrivateAttr()
@@ -131,8 +131,7 @@ class OutputPath(BaseModel):
         super().__init__(**data)
 
         __pydantic_self__._fsmap = fsspec.get_mapper(
-            __pydantic_self__.path,
-            **__pydantic_self__.storage_options
+            __pydantic_self__.path, **__pydantic_self__.storage_options
         )
         # Checks the file permission as the object is being created
         check_file_permissions(__pydantic_self__._fsmap)

--- a/seagap/configs/main.py
+++ b/seagap/configs/main.py
@@ -12,7 +12,7 @@ import yaml
 from pydantic import BaseModel, BaseSettings, Field, PrivateAttr
 from pydantic.fields import ModelField
 
-from ..utilities.io import check_file_permissions
+from ..utilities.io import check_permission
 from .solver import Solver
 
 CONFIG_FILE = "config.yaml"
@@ -134,7 +134,7 @@ class OutputPath(BaseModel):
             __pydantic_self__.path, **__pydantic_self__.storage_options
         )
         # Checks the file permission as the object is being created
-        check_file_permissions(__pydantic_self__._fsmap)
+        check_permission(__pydantic_self__._fsmap)
 
 
 class Configuration(BaseConfiguration):

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -137,8 +137,8 @@ class Solver(BaseModel):
     gps_sigma_limit: float = Field(
         0.05,
         description="Maximum positional sigma allowed to use GPS positions",
-        gt=0,
-        lt=100,
+        gt=0.0,
+        lt=100.0,
     )
     std_dev: bool = Field(
         True,
@@ -175,8 +175,8 @@ class Solver(BaseModel):
         which points will be excluded from solution"""
     )
     residual_limit: float = Field(
-        50,
-        ge=0,
+        50.0,
+        ge=0.0,
         description="""Maximum residual in centimeters beyond
         which data points will be excluded from solution"""
     )

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -168,6 +168,18 @@ class Solver(BaseModel):
     input_files: SolverInputs = Field(
         ..., description="Input files data path specifications."
     )
+    distance_limit: float = Field(
+        150.0,
+        ge=0.0,
+        description="""Distance in meters from center beyond
+        which points will be excluded from solution"""
+    )
+    residual_limit: float = Field(
+        50,
+        ge=0,
+        description="""Maximum residual in centimeters beyond
+        which data points will be excluded from solution"""
+    )
 
     @validator("transponder_wait_time")
     def check_transponder_wait_time(cls, v):

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -3,12 +3,12 @@
 The solver module containing base models for
 solver configuration
 """
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, List, Literal, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, PrivateAttr, validator
 
-from ..utilities.io import check_file_exists
+from .io import InputData
 
 
 class ReferenceEllipsoid(BaseModel):
@@ -37,29 +37,6 @@ class ArrayCenter(BaseModel):
 
     lat: float = Field(..., description="Latitude")
     lon: float = Field(..., description="Longitude")
-
-
-class InputData(BaseModel):
-    """Input data path specification base model"""
-
-    path: str = Field(
-        ...,
-        description="Path string to the data. Ex. s3://bucket/some_data.dat",
-    )
-    storage_options: Dict[str, Any] = Field(
-        {},
-        description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths""",
-    )
-
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        super().__init__(**data)
-
-        # Checks the file
-        if not check_file_exists(
-            __pydantic_self__.path, __pydantic_self__.storage_options
-        ):
-            raise FileNotFoundError("The specified file doesn't exist!")
 
 
 class SolverInputs(BaseModel):

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -3,7 +3,7 @@
 The solver module containing base models for
 solver configuration
 """
-from typing import Any, List, Literal, Optional, Dict
+from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, PrivateAttr, validator
@@ -41,15 +41,15 @@ class ArrayCenter(BaseModel):
 
 class SoundSpeed(BaseModel):
     """Sound speed base model."""
-    
+
     path: str = Field(
         ...,
-        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat"
+        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat",
     )
     storage_options: Dict[str, Any] = Field(
         {},
         description="""Protocol keyword argument for specified file system.
-        This is not needed for local paths"""
+        This is not needed for local paths""",
     )
 
     def __init__(__pydantic_self__, **data: Any) -> None:
@@ -57,11 +57,9 @@ class SoundSpeed(BaseModel):
 
         # Checks the file
         if not check_file_exists(
-            __pydantic_self__.path,
-            __pydantic_self__.storage_options
+            __pydantic_self__.path, __pydantic_self__.storage_options
         ):
             raise FileNotFoundError(f"The specified file doesn't exist!")
-
 
 
 class SolverGlobal(BaseModel):
@@ -155,10 +153,8 @@ class Solver(BaseModel):
         Options: ship/SV3 = 0.0s, WG = 0.1s""",
     )
     sound_speed: SoundSpeed = Field(
-        ...,
-        description="""Sound speed data directory for mean calculation"""
+        ..., description="""Sound speed data directory for mean calculation"""
     )
-
 
     @validator("transponder_wait_time")
     def check_transponder_wait_time(cls, v):

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -73,18 +73,22 @@ class SolverTransponder(BaseModel):
     height: float = Field(..., description="Transponder depth in meters (m).")
     internal_delay: float = Field(
         ...,
-        description="""Transponder internal delay in seconds (s).
-        Assume transponder delay contains:
-        delay-line, non-delay-line internal delays
-        (determined at transdec) and any user set delay (dail-in).""",
+        description=(
+            "Transponder internal delay in seconds (s). "
+            "Assume transponder delay contains: "
+            "delay-line, non-delay-line internal delays "
+            "(determined at transdec) and any user set delay (dail-in)."
+        ),
     )
     sv_mean: Optional[float] = Field(
-        None, description="""Dynamically generated sound velocity mean (m/s)."""
+        None, description="Dynamically generated sound velocity mean (m/s)."
     )
     pxp_id: Optional[str] = Field(
         None,
-        description="""Transponder id string.
-        **This field will be computed during object creation**""",
+        description=(
+            "Transponder id string. "
+            "**This field will be computed during object creation**"
+        ),
     )
     # Auto generated uuid per transponder for unique identifier
     _uuid: str = PrivateAttr()
@@ -139,8 +143,10 @@ class Solver(BaseModel):
     )
     transponder_wait_time: float = Field(
         0.0,
-        description="""Transponder Wait Time - delay at surface transducer (secs.).
-        Options: ship/SV3 = 0.0s, WG = 0.1s""",
+        description=(
+            "Transponder Wait Time - delay at surface transducer (secs.). "
+            "Options: ship/SV3 = 0.0s, WG = 0.1s"
+        ),
     )
     input_files: SolverInputs = Field(
         ..., description="Input files data path specifications."
@@ -148,14 +154,18 @@ class Solver(BaseModel):
     distance_limit: float = Field(
         150.0,
         ge=0.0,
-        description="""Distance in meters from center beyond
-        which points will be excluded from solution""",
+        description=(
+            "Distance in meters from center beyond "
+            "which points will be excluded from solution"
+        ),
     )
     residual_limit: float = Field(
         50.0,
         ge=0.0,
-        description="""Maximum residual in centimeters beyond
-        which data points will be excluded from solution""",
+        description=(
+            "Maximum residual in centimeters beyond "
+            "which data points will be excluded from solution"
+        ),
     )
 
     @validator("transponder_wait_time")

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -172,13 +172,13 @@ class Solver(BaseModel):
         150.0,
         ge=0.0,
         description="""Distance in meters from center beyond
-        which points will be excluded from solution"""
+        which points will be excluded from solution""",
     )
     residual_limit: float = Field(
         50.0,
         ge=0.0,
         description="""Maximum residual in centimeters beyond
-        which data points will be excluded from solution"""
+        which data points will be excluded from solution""",
     )
 
     @validator("transponder_wait_time")

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -59,7 +59,7 @@ class SoundSpeed(BaseModel):
         if not check_file_exists(
             __pydantic_self__.path, __pydantic_self__.storage_options
         ):
-            raise FileNotFoundError(f"The specified file doesn't exist!")
+            raise FileNotFoundError("The specified file doesn't exist!")
 
 
 class SolverGlobal(BaseModel):

--- a/seagap/configs/solver.py
+++ b/seagap/configs/solver.py
@@ -39,12 +39,12 @@ class ArrayCenter(BaseModel):
     lon: float = Field(..., description="Longitude")
 
 
-class SoundSpeed(BaseModel):
-    """Sound speed base model."""
+class InputData(BaseModel):
+    """Input data path specification base model"""
 
     path: str = Field(
         ...,
-        description="Path string to the sound speed data. Ex. s3://bucket/ctd_sound_speed.dat",
+        description="Path string to the data. Ex. s3://bucket/some_data.dat",
     )
     storage_options: Dict[str, Any] = Field(
         {},
@@ -60,6 +60,19 @@ class SoundSpeed(BaseModel):
             __pydantic_self__.path, __pydantic_self__.storage_options
         ):
             raise FileNotFoundError("The specified file doesn't exist!")
+
+
+class SolverInputs(BaseModel):
+    sound_speed: InputData = Field(
+        ..., description="Sound speed data path specification"
+    )
+    # NOTE: 3/3/2023 - These are required for now and will change in the future.
+    travel_times: InputData = Field(
+        ..., description="Travel times data path specification."
+    )
+    gps_solution: InputData = Field(
+        ..., description="GPS solution data path specification."
+    )
 
 
 class SolverGlobal(BaseModel):
@@ -152,8 +165,8 @@ class Solver(BaseModel):
         description="""Transponder Wait Time - delay at surface transducer (secs.).
         Options: ship/SV3 = 0.0s, WG = 0.1s""",
     )
-    sound_speed: SoundSpeed = Field(
-        ..., description="""Sound speed data directory for mean calculation"""
+    input_files: SolverInputs = Field(
+        ..., description="Input files data path specifications."
     )
 
     @validator("transponder_wait_time")

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -1,23 +1,67 @@
 import os
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 import fsspec
 
 
-def check_file_exists(file_path, storage_options):
-    parsed_path = urlparse(file_path)
-    fs = fsspec.filesystem(parsed_path.scheme, **storage_options)
-    return fs.exists(file_path)
+def check_file_exists(input_path: str, storage_options: Dict[str, Any]) -> bool:
+    """
+    Perform a check if either file or directory exists
+    by parsing the `input_path` into a parsed url,
+    extracting the scheme, and running a check.
+
+    Parameters
+    ----------
+    input_path : str
+        Input path string. This can be a url path,
+        such as `s3://mybucket/path`
+    storage_options : dict
+        Protocol keyword argument for specified file system.
+        This is not needed for local paths.
+
+    Returns
+    -------
+    bool
+        A flag that indicates whether file or directory exists.
+    """
+    parsed_url = urlparse(input_path)
+    fs = fsspec.filesystem(parsed_url.scheme, **storage_options)
+    if "**" in parsed_url.path:
+        # Grab directory location for glob string
+        check_path = parsed_url.path.split("**")[0]
+    else:
+        check_path = input_path
+    return fs.exists(check_path)
 
 
-def check_file_permissions(FILE_DIR):
+def check_permission(input_path: fsspec.FSMap) -> None:
+    """
+    Perform permission check to a file directory as specified.
+    This function will attempt to write a file called `.permission_test`
+    in the base directory.
+
+    Parameters
+    ----------
+    input_path : fsspec.FSMap
+        Input path as mutable mapping
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    PermissionError
+        If the directory is not writable
+    """
     try:
-        base_dir = os.path.dirname(FILE_DIR.root)
+        base_dir = os.path.dirname(input_path.root)
         if not base_dir:
-            base_dir = FILE_DIR.root
+            base_dir = input_path.root
         TEST_FILE = os.path.join(base_dir, ".permission_test").replace("\\", "/")
-        with FILE_DIR.fs.open(TEST_FILE, "w") as f:
+        with input_path.fs.open(TEST_FILE, "w") as f:
             f.write("testing\n")
-        FILE_DIR.fs.delete(TEST_FILE)
+        input_path.fs.delete(TEST_FILE)
     except Exception:  # noqa
         raise PermissionError("Writing to specified path is not permitted.")

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -15,7 +15,8 @@ def check_file_exists(input_path: str, storage_options: Dict[str, Any] = {}) -> 
     ----------
     input_path : str
         Input path string. This can be a url path,
-        such as `s3://mybucket/path`
+        such as `s3://mybucket/file.dat` or
+        `s3://mybucket/**/myfile.csv`
     storage_options : dict
         Protocol keyword argument for specified file system.
         This is not needed for local paths.
@@ -24,6 +25,12 @@ def check_file_exists(input_path: str, storage_options: Dict[str, Any] = {}) -> 
     -------
     bool
         A flag that indicates whether file or directory exists.
+
+    Notes
+    -----
+    In the case of a glob path string (has ``**``), the function will
+    travese through all child directories until it finds the specified
+    file matching the pattern.
     """
     parsed_url = urlparse(input_path)
     fs = fsspec.filesystem(parsed_url.scheme, **storage_options)
@@ -59,7 +66,7 @@ def check_permission(input_path: fsspec.FSMap) -> None:
         base_dir = os.path.dirname(input_path.root)
         if not base_dir:
             base_dir = input_path.root
-        TEST_FILE = os.path.join(base_dir, ".permission_test").replace("\\", "/")
+        TEST_FILE = os.path.join(base_dir, ".permission_test")
         with input_path.fs.open(TEST_FILE, "w") as f:
             f.write("testing\n")
         input_path.fs.delete(TEST_FILE)

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -1,0 +1,21 @@
+import os
+import fsspec
+from urllib.parse import urlparse
+
+def check_file_exists(file_path, storage_options):
+    parsed_path = urlparse(file_path)
+    fs = fsspec.filesystem(parsed_path.scheme, **storage_options)
+    return fs.exists(file_path)
+
+
+def check_file_permissions(FILE_DIR):
+    try:
+        base_dir = os.path.dirname(FILE_DIR.root)
+        if not base_dir:
+            base_dir = FILE_DIR.root
+        TEST_FILE = os.path.join(base_dir, ".permission_test").replace("\\", "/")
+        with FILE_DIR.fs.open(TEST_FILE, "w") as f:
+            f.write("testing\n")
+        FILE_DIR.fs.delete(TEST_FILE)
+    except Exception:  # noqa
+        raise PermissionError("Writing to specified path is not permitted.")

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 import fsspec
 
 
-def check_file_exists(input_path: str, storage_options: Dict[str, Any]) -> bool:
+def check_file_exists(input_path: str, storage_options: Dict[str, Any] = {}) -> bool:
     """
     Perform a check if either file or directory exists
     by parsing the `input_path` into a parsed url,

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -1,6 +1,8 @@
 import os
-import fsspec
 from urllib.parse import urlparse
+
+import fsspec
+
 
 def check_file_exists(file_path, storage_options):
     parsed_path = urlparse(file_path)

--- a/seagap/utilities/io.py
+++ b/seagap/utilities/io.py
@@ -29,7 +29,7 @@ def check_file_exists(input_path: str, storage_options: Dict[str, Any] = {}) -> 
     Notes
     -----
     In the case of a glob path string (has ``**``), the function will
-    travese through all child directories until it finds the specified
+    traverse through all child directories until it finds the specified
     file matching the pattern.
     """
     parsed_url = urlparse(input_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages = find:
 platforms = any
 include_package_data = True
 install_requires =
+    fsspec
     numpy
     numba
     pandas

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -1,0 +1,63 @@
+from tempfile import mkstemp, mkdtemp
+from pathlib import Path
+import stat
+import os
+
+import fsspec
+import pytest
+
+from seagap.utilities.io import check_file_exists, check_permission
+
+PREFIX = "seagap-"
+
+@pytest.fixture(params=["single", "glob", "random"])
+def input_path(request):
+    # TODO: Add remote file test
+    _, tmp_file = mkstemp(prefix=PREFIX)
+    file_path = Path(tmp_file)
+    file_dir = file_path.parent
+    if request.param == "single":
+        return file_path, str(file_path)
+    elif request.param == "glob":
+        # Get file directory 2 level above
+        dir_path = str(file_dir.parent)
+        return file_path, f"{dir_path}/**/{file_path.name}"
+    elif request.param == "random":
+        return "./non_existent"
+
+
+def test_check_file_exists(input_path):
+    """Tests the `check_file_exists` io function"""
+    file_path = None
+    if isinstance(input_path, str):
+        # A non existent file ... only path string
+        expected_value = False
+        test_path = input_path
+    else:
+        expected_value = True
+        file_path, test_path = input_path
+
+    assert isinstance(check_file_exists(test_path), bool) is True
+    assert check_file_exists(test_path) is expected_value
+    
+    # Clean up after
+    if file_path is not None:
+        os.unlink(file_path)
+
+@pytest.mark.parametrize("has_permission", [True, False])
+def test_check_permission(has_permission):
+    """Tests the `check_permission` io function"""
+    # TODO: Add remote file test
+    temp_path = mkdtemp(prefix=PREFIX)
+    if not has_permission:
+       # Change directory permission to read only
+       os.chmod(temp_path, stat.S_IREAD)
+
+    fmap = fsspec.get_mapper(temp_path)
+    try:
+        # This should pass when there's permission
+        # otherwise check that during a PermissionError
+        # `has_permission` is False
+        check_permission(input_path=fmap)
+    except PermissionError:
+        assert has_permission is False

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -35,11 +35,8 @@ def input_path(request):
 
 def test_check_file_exists(input_path):
     """Tests the `check_file_exists` io function"""
-    if "non_existent" in input_path:
-        # A non existent file ... only path string
-        expected_value = False
-    else:
-        expected_value = True
+    # A non existent file ... only path string
+    expected_value = "non_existent" not in input_path
 
     assert isinstance(check_file_exists(input_path), bool) is True
     assert check_file_exists(input_path) is expected_value

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -21,8 +21,8 @@ def input_path(request):
         return file_path, str(file_path)
     elif request.param == "glob":
         # Get file directory 2 level above
-        dir_path = str(file_dir.parent)
-        return file_path, f"{dir_path}/**/{file_path.name}"
+        dir_path = file_dir.parent / "**" / file_path.name
+        return file_path, str(dir_path)
     elif request.param == "random":
         return "./non_existent"
 

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -1,7 +1,7 @@
-from tempfile import mkstemp, mkdtemp
-from pathlib import Path
-import stat
 import os
+import stat
+from pathlib import Path
+from tempfile import mkdtemp, mkstemp
 
 import fsspec
 import pytest
@@ -9,6 +9,7 @@ import pytest
 from seagap.utilities.io import check_file_exists, check_permission
 
 PREFIX = "seagap-"
+
 
 @pytest.fixture(params=["single", "glob", "random"])
 def input_path(request):
@@ -39,10 +40,11 @@ def test_check_file_exists(input_path):
 
     assert isinstance(check_file_exists(test_path), bool) is True
     assert check_file_exists(test_path) is expected_value
-    
+
     # Clean up after
     if file_path is not None:
         os.unlink(file_path)
+
 
 @pytest.mark.parametrize("has_permission", [True, False])
 def test_check_permission(has_permission):
@@ -50,8 +52,8 @@ def test_check_permission(has_permission):
     # TODO: Add remote file test
     temp_path = mkdtemp(prefix=PREFIX)
     if not has_permission:
-       # Change directory permission to read only
-       os.chmod(temp_path, stat.S_IREAD)
+        # Change directory permission to read only
+        os.chmod(temp_path, stat.S_IREAD)
 
     fmap = fsspec.get_mapper(temp_path)
     try:

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -1,7 +1,7 @@
 import os
 import stat
 from pathlib import Path
-from tempfile import mkdtemp, mkstemp
+from tempfile import mkstemp, TemporaryDirectory
 
 import fsspec
 import pytest
@@ -16,50 +16,49 @@ def input_path(request):
     # TODO: Add remote file test
     _, tmp_file = mkstemp(prefix=PREFIX)
     file_path = Path(tmp_file)
-    file_dir = file_path.parent
     if request.param == "single":
-        return file_path, str(file_path)
+        file_path = str(file_path)
     elif request.param == "glob":
         # Get file directory 2 level above
+        file_dir = file_path.parent
         dir_path = file_dir.parent / "**" / file_path.name
-        return file_path, str(dir_path)
+        file_path = str(dir_path)
     elif request.param == "random":
-        return "./non_existent"
+        file_path = "./non_existent"
+    
+    yield file_path
+
+    # Clean up after
+    if os.path.exists(file_path):
+        os.unlink(file_path)
 
 
 def test_check_file_exists(input_path):
     """Tests the `check_file_exists` io function"""
-    file_path = None
-    if isinstance(input_path, str):
+    if "non_existent" in input_path:
         # A non existent file ... only path string
         expected_value = False
-        test_path = input_path
     else:
         expected_value = True
-        file_path, test_path = input_path
 
-    assert isinstance(check_file_exists(test_path), bool) is True
-    assert check_file_exists(test_path) is expected_value
-
-    # Clean up after
-    if file_path is not None:
-        os.unlink(file_path)
+    assert isinstance(check_file_exists(input_path), bool) is True
+    assert check_file_exists(input_path) is expected_value
 
 
 @pytest.mark.parametrize("has_permission", [True, False])
 def test_check_permission(has_permission):
     """Tests the `check_permission` io function"""
     # TODO: Add remote file test
-    temp_path = mkdtemp(prefix=PREFIX)
-    if not has_permission:
-        # Change directory permission to read only
-        os.chmod(temp_path, stat.S_IREAD)
+    with TemporaryDirectory(prefix=PREFIX) as temp_path:
+        if not has_permission:
+            # Change directory permission to read only
+            os.chmod(temp_path, stat.S_IREAD)
 
-    fmap = fsspec.get_mapper(temp_path)
-    try:
-        # This should pass when there's permission
-        # otherwise check that during a PermissionError
-        # `has_permission` is False
-        check_permission(input_path=fmap)
-    except PermissionError:
-        assert has_permission is False
+        fmap = fsspec.get_mapper(temp_path)
+        try:
+            # This should pass when there's permission
+            # otherwise check that during a PermissionError
+            # `has_permission` is False
+            check_permission(input_path=fmap)
+        except PermissionError:
+            assert has_permission is False

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -1,7 +1,7 @@
 import os
 import stat
 from pathlib import Path
-from tempfile import mkstemp, TemporaryDirectory
+from tempfile import TemporaryDirectory, mkstemp
 
 import fsspec
 import pytest
@@ -25,7 +25,7 @@ def input_path(request):
         file_path = str(dir_path)
     elif request.param == "random":
         file_path = "./non_existent"
-    
+
     yield file_path
 
     # Clean up after

--- a/tests/utilities/test_io.py
+++ b/tests/utilities/test_io.py
@@ -9,6 +9,7 @@ import pytest
 from seagap.utilities.io import check_file_exists, check_permission
 
 PREFIX = "seagap-"
+NON_EXISTENT = "non_existent"
 
 
 @pytest.fixture(params=["single", "glob", "random"])
@@ -24,7 +25,7 @@ def input_path(request):
         dir_path = file_dir.parent / "**" / file_path.name
         file_path = str(dir_path)
     elif request.param == "random":
-        file_path = "./non_existent"
+        file_path = f"./{NON_EXISTENT}"
 
     yield file_path
 
@@ -36,7 +37,7 @@ def input_path(request):
 def test_check_file_exists(input_path):
     """Tests the `check_file_exists` io function"""
     # A non existent file ... only path string
-    expected_value = "non_existent" not in input_path
+    expected_value = NON_EXISTENT not in input_path
 
     assert isinstance(check_file_exists(input_path), bool) is True
     assert check_file_exists(input_path) is expected_value


### PR DESCRIPTION
## Overview

This PR adds I/O utility functions and also add `sound_speed`, `travel_times`, and `gps_positions` path configuration. Additionally, this PR adds a way to input `distance_limit` and `residual_limit` values to the solver configuration.

## Design

```
solver:
  ...
  input_files:
    sound_speed:
      path: /path/to/ctd/CTD_NCL1_Ch_Mi
      storage_options: {}
   travel_times:
      path: /some/pxp_data/dir/**/pxp_tt
      storage_options: {}
    gps_positions:
      path: /some/gps_data/dir/**/POS_FREED_TRANS_TWTT
      storage_options: {}

output:
  path: /some/output/dir
  storage_options: {}
```

## TODO
- [x] Add file permission checking for output
- [x] Add file exists checking for input
- [x] Add sound speed input config
- [x] Add `pxp_data` input config
- [x] Add `gps_data` input config
- [x] Add test for io functions

## Related Issues
- #19 
- #21