### PR TITLE
Remove setuptools python install for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,6 +29,4 @@ python:
         path: .
         extra_requirements:
            - docs
-      - method: setuptools
-        path: .
 #   system_packages: true


### PR DESCRIPTION
## Overview

This PR removes the need to install with setuptools since we're using hatch here.