### PR TITLE
Update load travel times to include j2000

### DIFF
--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -146,6 +146,9 @@ def load_travel_times(
     # Set standard column name
     all_travel_times.columns = columns
 
+    # Convert microseconds to seconds for delay times
+    all_travel_times[transponder_labels] = all_travel_times[transponder_labels] * 1e-6
+
     # Skip time conversion if it's already j2000 time
     if not is_j2k:
         from .utilities.time import AstroTime


### PR DESCRIPTION
## Overview

The travel times files `pxp_tt` has 2 separate structures, which is stored in another file called `pxp_tt_j2k`. This file already has the time component as J2000 epoch time float and need to be handled. This update come about after conversation with @johnbdesanto yesterday. The change included in this PR is having an `is_j2k` flag, so that if this is `True` it means that we are expecting the `pxp_tt_j2k` file rather than the `pxp_tt`.