### PR TITLE
Bump min py >= 3.9 and pin dependencies max

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         experimental: [false]
     steps:
     - name: Checkout Repo

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,33 +8,33 @@ dynamic = ["version"]
 description = "Community Seafloor Global Navigation Satellite Systems - Acoustic (GNSS-A) Transponder Surveying Software"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "astropy>=5.2.2",
-    "fsspec>=2023.3.0",
-    "numba>=0.56.4",
-    "numpy>=1.23.5",
-    "nptyping>=2.5.0",
-    "cftime>=1.6.2",
-    "pandas>=1.5.3",
+    "astropy>=5.2.2,<6",
+    "fsspec>=2023.3.0,<2024",
+    "numba>=0.56.4,<1",
+    "numpy>=1.23.5,<2",
+    "nptyping>=2.5.0,<3",
+    "cftime>=1.6.2,<2",
+    "pandas>=2.0.3,<3",
     "pydantic>=1.10.6,<2",
-    "pyyaml>=5.4",
-    "pymap3d>=3.0.1",
-    "pluggy>=1.0.0",
-    "pyproj>=3.5.0",
-    "scipy>=1.10.1",
+    "pyyaml>=6.0.1,<7",
+    "pymap3d>=3.0.1,<4",
+    "pluggy>=1.2.0,<2",
+    "pyproj>=3.5.0,<4",
+    "scipy>=1.10.1,<2",
     "typer>=0.7.0,<1"
 ]
 

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -232,8 +232,13 @@ def load_deletions(file_path: str) -> pd.DataFrame:
     from .utilities.time import AstroTime
 
     cut_df = pd.read_fwf(file_path, header=None)
-    cut_df[constants.DEL_STARTTIME] = pd.to_datetime(cut_df[0] + "T" + cut_df[1])
-    cut_df[constants.DEL_ENDTIME] = pd.to_datetime(cut_df[2] + "T" + cut_df[3])
+    # Date example: 28-JUL-22 12:30:00
+    cut_df[constants.DEL_STARTTIME] = pd.to_datetime(
+        cut_df[0] + "T" + cut_df[1], format="%d-%b-%yT%H:%M:%S"
+    )
+    cut_df[constants.DEL_ENDTIME] = pd.to_datetime(
+        cut_df[2] + "T" + cut_df[3], format="%d-%b-%yT%H:%M:%S"
+    )
     # Got rid of the other columns
     # TODO: Parse the other columns
     cut_columns = cut_df.columns[0:-2]


### PR DESCRIPTION
## Overview

This PR bumps the minimum python version to 3.9 to stay up to date since it's still supported until october of this year. Additionally, this pins dependencies max versions to prevent things from breaking from future releases.