### PR TITLE
test(seagap): add test case to raise ValueError

### DIFF
--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -68,8 +68,15 @@ def test__compute_hm_missing_columns():
 
 
 # Add test for empty dataframe
+# def test_sv_harmonic_mean_empty_dataframe():
+#     svdf = pd.DataFrame()
+#     start_depth = 0
+#     end_depth = 2
+#     with pytest.raises(ValueError):
+#         sv_harmonic_mean(svdf, start_depth, end_depth)
 def test_sv_harmonic_mean_empty_dataframe():
-    svdf = pd.DataFrame()
+    # Create a DataFrame with empty 'abs_sv' column
+    svdf = pd.DataFrame({"speed": [], "depth": []})
     start_depth = 0
     end_depth = 2
     with pytest.raises(ValueError):

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -56,3 +56,29 @@ def test__compute_hm(start_idx, end_idx, expected_hm):
     x = partdf[SP_SOUND_SPEED]
     H = w.dropna().sum() / (w / x).dropna().sum()
     assert result_hm == round(H, 3)
+
+
+@pytest.mark.parametrize(
+    "end_depth,expected_hm",
+    [("invalid_value", None)],  # Invalid end_depth input will raise ValueError
+)
+def test_sv_harmonic_mean_invalid_input(end_depth, expected_hm, sound_profile_data):
+    svdf = sound_profile_data
+    start_depth = -4
+    with pytest.raises(ValueError):
+        sv_harmonic_mean(svdf, start_depth, end_depth)
+
+
+@pytest.mark.parametrize(
+    "start_idx,end_idx,expected_hm",
+    [("invalid_value", None)],  # Invalid end_depth input will raise ValueError
+)
+def test__compute_hm_invalid_input(start_idx, end_idx, expected_hm):
+    depth = np.arange(7) * 10
+    speed = np.arange(1502, 1500, step=-0.31)
+
+    svdf = pd.DataFrame({SP_DEPTH: depth, SP_SOUND_SPEED: speed})
+
+    start_depth = 0
+    with pytest.raises(ValueError):
+        _compute_hm(svdf, start_depth, end_idx)

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -58,26 +58,19 @@ def test__compute_hm(start_idx, end_idx, expected_hm):
     assert result_hm == round(H, 3)
 
 
-@pytest.mark.parametrize(
-    "end_depth,expected_hm",
-    [("invalid_value", None)],  # Invalid end_depth input will raise ValueError
-)
-def test_sv_harmonic_mean_invalid_input(end_depth, expected_hm, sound_profile_data):
-    svdf = sound_profile_data
-    start_depth = -4
+# Add test for missing columns in dataframe
+def test__compute_hm_missing_columns():
+    svdf = pd.DataFrame({"random_column1": [1, 2, 3], "random_column2": [4, 5, 6]})
+    start_depth = 0
+    end_depth = 2
+    with pytest.raises(ValueError):
+        _compute_hm(svdf, start_depth, end_depth)
+
+
+# Add test for empty dataframe
+def test_sv_harmonic_mean_empty_dataframe():
+    svdf = pd.DataFrame()
+    start_depth = 0
+    end_depth = 2
     with pytest.raises(ValueError):
         sv_harmonic_mean(svdf, start_depth, end_depth)
-
-
-@pytest.mark.parametrize(
-    "start_idx,end_idx,expected_hm",
-    [("invalid_value", "invalid_value", None)],
-)
-def test__compute_hm_invalid_input(start_idx, end_idx, expected_hm):
-    depth = np.arange(7) * 10
-    speed = np.arange(1502, 1500, step=-0.31)
-
-    svdf = pd.DataFrame({SP_DEPTH: depth, SP_SOUND_SPEED: speed})
-
-    with pytest.raises(ValueError):
-        _compute_hm(svdf, start_idx, end_idx)

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -68,12 +68,6 @@ def test__compute_hm_missing_columns():
 
 
 # Add test for empty dataframe
-# def test_sv_harmonic_mean_empty_dataframe():
-#     svdf = pd.DataFrame()
-#     start_depth = 0
-#     end_depth = 2
-#     with pytest.raises(ValueError):
-#         sv_harmonic_mean(svdf, start_depth, end_depth)
 def test_sv_harmonic_mean_empty_dataframe():
     # Create a DataFrame with empty 'abs_sv' column
     svdf = pd.DataFrame({"speed": [], "depth": []})

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -71,7 +71,7 @@ def test_sv_harmonic_mean_invalid_input(end_depth, expected_hm, sound_profile_da
 
 @pytest.mark.parametrize(
     "start_idx,end_idx,expected_hm",
-    [("invalid_value", None)],  # Invalid end_depth input will raise ValueError
+    [("invalid_value", "invalid_value", None)],
 )
 def test__compute_hm_invalid_input(start_idx, end_idx, expected_hm):
     depth = np.arange(7) * 10
@@ -79,6 +79,5 @@ def test__compute_hm_invalid_input(start_idx, end_idx, expected_hm):
 
     svdf = pd.DataFrame({SP_DEPTH: depth, SP_SOUND_SPEED: speed})
 
-    start_depth = 0
     with pytest.raises(ValueError):
-        _compute_hm(svdf, start_depth, end_idx)
+        _compute_hm(svdf, start_idx, end_idx)


### PR DESCRIPTION
Hi @lsetiawan ，
I've finished L1 task (Offshore Geodesy - Add test case to raise ValueError) and added two new test cases in tests/test_harmonic_mean.py. One test case error reported by the unit test has been fixed.

test_sv_harmonic_mean_invalid_input: This test case checks if the sv_harmonic_mean function raises a ValueError when provided with an invalid end_depth input (in this case, a string instead of a float or integer).

test__compute_hm_invalid_input: This test case checks if the _compute_hm function raises a ValueError when provided with an invalid end_depth input (in this case, a string instead of a float or integer).

These test cases will ensure that the ValueError scenarios in both sv_harmonic_mean and _compute_hm functions are properly covered during testing.

Reference: https://github.com/uw-ssec/codeuw/issues/23