### PR TITLE
Offshore Geodesy - Add testing for the time.py utility module

### DIFF
--- a/src/gnatss/utilities/time.py
+++ b/src/gnatss/utilities/time.py
@@ -17,7 +17,7 @@ class TimeUnixJ2000(TimeFromEpoch):
 
     name = "unix_j2000"
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
-    epoch_val = "2000-01-01 11:58:55.816"
+    epoch_val = "2000-01-01 12:00:00"
     epoch_val2 = None
-    epoch_scale = "utc"  # Scale for epoch_val class attribute
+    epoch_scale = "tt"  # Scale for epoch_val class attribute
     epoch_format = "iso"  # Format for epoch_val class attribute

--- a/src/gnatss/utilities/time.py
+++ b/src/gnatss/utilities/time.py
@@ -4,23 +4,20 @@ Time utilities module utilizing astropy
 """
 from astropy.time import Time as AstroTime  # noqa
 from astropy.time.formats import TimeFromEpoch, erfa
+from astropy.units import isclose
+
+__all__ = ["AstroTime", "erfa", "isclose"]
 
 
 class TimeUnixJ2000(TimeFromEpoch):
-
     """
-
-    Seconds from 2000-01-01 12:00:00 UTC
-
+    Seconds from 2000-01-01 12:00:00 TT (equivalent to 2000-01-01 11:58:55.816 UTC),
+    ignoring leap seconds.
     """
 
     name = "unix_j2000"
-
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
-
-    epoch_val = "2000-01-01 12:00:00"
-
+    epoch_val = "2000-01-01 11:58:55.816"
     epoch_val2 = None
-
     epoch_scale = "utc"  # Scale for epoch_val class attribute
     epoch_format = "iso"  # Format for epoch_val class attribute

--- a/tests/utilities/test_time.py
+++ b/tests/utilities/test_time.py
@@ -1,0 +1,34 @@
+from gnatss.utilities.time import AstroTime, erfa
+
+DATETIME_FORMAT = "%Y-%b-%dT%H:%M:%S.%f"
+
+
+def test_unix_j2000_time_format():
+    """Tests custom time format unix_j2000"""
+
+    first_jan_2000_noon_unix_j2000 = AstroTime(0.0, format="unix_j2000")
+    first_jan_2000_noon_utc = AstroTime.strptime(
+        "2000-Jan-01T12:00:00.000", DATETIME_FORMAT, scale="utc"
+    )
+    assert (
+        first_jan_2000_noon_unix_j2000.unix_j2000
+        == first_jan_2000_noon_utc.unix_j2000
+        == 0.0
+    )
+
+    # Number of seconds elapsed from 01-Jan-2000-noon-utc to 02_Feb-2004-noon-utc
+    secs_elapsed_till_second_feb_2004_noon = float(
+        ((365 + 365 + 365 + 366) + 31 + 1) * erfa.DAYSEC
+    )
+
+    second_feb_2004_noon_unix_j2000 = AstroTime(
+        0.0 + secs_elapsed_till_second_feb_2004_noon, format="unix_j2000"
+    )
+    second_feb_2004_noon_utc = AstroTime.strptime(
+        "2004-Feb-02T12:00:00.000", DATETIME_FORMAT, scale="utc"
+    )
+    assert (
+        second_feb_2004_noon_unix_j2000.unix_j2000
+        == second_feb_2004_noon_utc.unix_j2000
+        == secs_elapsed_till_second_feb_2004_noon
+    )

--- a/tests/utilities/test_time.py
+++ b/tests/utilities/test_time.py
@@ -1,6 +1,8 @@
+import pytest
+
 from gnatss.utilities.time import AstroTime, erfa, isclose
 
-DATETIME_FORMAT = "%Y-%b-%dT%H:%M:%S.%f"
+DATETIME_FORMAT = "%Y-%b-%d %H:%M:%S.%f"
 
 
 def test_unix_j2000_time_format():
@@ -11,10 +13,10 @@ def test_unix_j2000_time_format():
 
     first_jan_2000_noon_unix_j2000 = AstroTime(0.0, format="unix_j2000")
     initial_unix_j2000_tt = AstroTime.strptime(
-        "2000-Jan-01T12:00:00.000", DATETIME_FORMAT, scale="tt"
+        "2000-Jan-01 12:00:00.000", DATETIME_FORMAT, scale="tt"
     )
     initial_unix_j2000_utc = AstroTime.strptime(
-        "2000-Jan-01T11:58:55.816", DATETIME_FORMAT, scale="utc"
+        "2000-Jan-01 11:58:55.816", DATETIME_FORMAT, scale="utc"
     )
     assert isclose(first_jan_2000_noon_unix_j2000.unix_j2000, 0.0, atol=1e-3)
     assert isclose(initial_unix_j2000_tt.unix_j2000, 0.0, atol=1e-3)
@@ -29,10 +31,10 @@ def test_unix_j2000_time_format():
         0.0 + secs_elapsed_till_second_feb_2004_noon, format="unix_j2000"
     )
     elapsed_unix_j2000_tt = AstroTime.strptime(
-        "2004-Feb-02T12:00:00.000", DATETIME_FORMAT, scale="tt"
+        "2004-Feb-02 12:00:00.000", DATETIME_FORMAT, scale="tt"
     )
     elapsed_unix_j2000_utc = AstroTime.strptime(
-        "2004-Feb-02T11:58:55.816", DATETIME_FORMAT, scale="utc"
+        "2004-Feb-02 11:58:55.816", DATETIME_FORMAT, scale="utc"
     )
     assert isclose(
         second_feb_2004_noon_unix_j2000.unix_j2000,
@@ -49,3 +51,21 @@ def test_unix_j2000_time_format():
         secs_elapsed_till_second_feb_2004_noon,
         atol=1e-3,
     )
+
+
+@pytest.mark.parametrize(
+    "unix_j2000, expected_iso",
+    [
+        (712215465.0, "2022-07-27 17:37:45.000"),
+        (712215465, "2022-07-27 17:37:45.000"),
+        ("712215465.0", "2022-07-27 17:37:45.000"),
+        (712215465, "2022-07-27 17:37:45.000"),
+        ("2022-07-27 17:37:45.000", None),
+    ],
+)
+def test_unix_j2000_convert_to_iso(unix_j2000, expected_iso):
+    if unix_j2000 == "2022-07-27 17:37:45.000":
+        with pytest.raises(ValueError):
+            AstroTime(unix_j2000, format="unix_j2000").iso
+    else:
+        assert AstroTime(unix_j2000, format="unix_j2000").iso == expected_iso

--- a/tests/utilities/test_time.py
+++ b/tests/utilities/test_time.py
@@ -1,34 +1,51 @@
-from gnatss.utilities.time import AstroTime, erfa
+from gnatss.utilities.time import AstroTime, erfa, isclose
 
 DATETIME_FORMAT = "%Y-%b-%dT%H:%M:%S.%f"
 
 
 def test_unix_j2000_time_format():
-    """Tests custom time format unix_j2000"""
+    """
+    Tests custom time format unix_j2000.
+    Calculated times are verified with millisecond level tolerance.
+    """
 
     first_jan_2000_noon_unix_j2000 = AstroTime(0.0, format="unix_j2000")
-    first_jan_2000_noon_utc = AstroTime.strptime(
-        "2000-Jan-01T12:00:00.000", DATETIME_FORMAT, scale="utc"
+    initial_unix_j2000_tt = AstroTime.strptime(
+        "2000-Jan-01T12:00:00.000", DATETIME_FORMAT, scale="tt"
     )
-    assert (
-        first_jan_2000_noon_unix_j2000.unix_j2000
-        == first_jan_2000_noon_utc.unix_j2000
-        == 0.0
+    initial_unix_j2000_utc = AstroTime.strptime(
+        "2000-Jan-01T11:58:55.816", DATETIME_FORMAT, scale="utc"
     )
+    assert isclose(first_jan_2000_noon_unix_j2000.unix_j2000, 0.0, atol=1e-3)
+    assert isclose(initial_unix_j2000_tt.unix_j2000, 0.0, atol=1e-3)
+    assert isclose(initial_unix_j2000_utc.unix_j2000, 0.0, atol=1e-3)
 
-    # Number of seconds elapsed from 01-Jan-2000-noon-utc to 02_Feb-2004-noon-utc
+    # Number of seconds elapsed from 01-Jan-2000-noon-tt to 02_Feb-2004-noon-tt
     secs_elapsed_till_second_feb_2004_noon = float(
-        ((365 + 365 + 365 + 366) + 31 + 1) * erfa.DAYSEC
+        ((366 + 365 + 365 + 365) + 31 + 1) * erfa.DAYSEC
     )
 
     second_feb_2004_noon_unix_j2000 = AstroTime(
         0.0 + secs_elapsed_till_second_feb_2004_noon, format="unix_j2000"
     )
-    second_feb_2004_noon_utc = AstroTime.strptime(
-        "2004-Feb-02T12:00:00.000", DATETIME_FORMAT, scale="utc"
+    elapsed_unix_j2000_tt = AstroTime.strptime(
+        "2004-Feb-02T12:00:00.000", DATETIME_FORMAT, scale="tt"
     )
-    assert (
-        second_feb_2004_noon_unix_j2000.unix_j2000
-        == second_feb_2004_noon_utc.unix_j2000
-        == secs_elapsed_till_second_feb_2004_noon
+    elapsed_unix_j2000_utc = AstroTime.strptime(
+        "2004-Feb-02T11:58:55.816", DATETIME_FORMAT, scale="utc"
+    )
+    assert isclose(
+        second_feb_2004_noon_unix_j2000.unix_j2000,
+        secs_elapsed_till_second_feb_2004_noon,
+        atol=1e-3,
+    )
+    assert isclose(
+        elapsed_unix_j2000_tt.unix_j2000,
+        secs_elapsed_till_second_feb_2004_noon,
+        atol=1e-3,
+    )
+    assert isclose(
+        elapsed_unix_j2000_utc.unix_j2000,
+        secs_elapsed_till_second_feb_2004_noon,
+        atol=1e-3,
     )


### PR DESCRIPTION
* Add unittest to verify working of custom subclass "TimeUnixJ2000" of astropy's "TimeFromEpoch".
* Linked to issue [uw-ssec/codeuw/issues/29](https://github.com/uw-ssec/codeuw/issues/29)