### PR TITLE
ci: add test annotations and change workflow name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on: [push, pull_request]
 
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3.5.3
+      with:
+        fetch-depth: 0 # Fetch all history for all branches and tags.
     - name: Setup Python
       uses: actions/setup-python@v4.7.0
       with:
@@ -27,6 +29,12 @@ jobs:
       run: |
         import platform
         print(platform.machine().lower())
+    # We only want to install this on one run, because otherwise we'll have
+    # duplicate annotations.
+    - name: Install error reporter
+      if: ${{ matrix.python-version == '3.10' }}
+      run: |
+        python -m pip install pytest-github-actions-annotate-failures
     - name: Install project
       run: pip install ".[test]"
     - name: Prepare fortran modules

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <span><img src="https://img.shields.io/badge/SSEC-Project-purple?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic" /><span>
 <br>
-[![Test](https://github.com/uw-ssec/offshore-geodesy/actions/workflows/test.yaml/badge.svg)](https://github.com/uw-ssec/offshore-geodesy/actions/workflows/test.yaml)
+[![CI](https://github.com/uw-ssec/offshore-geodesy/actions/workflows/ci.yaml/badge.svg)](https://github.com/uw-ssec/offshore-geodesy/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/uw-ssec/offshore-geodesy/branch/main/graph/badge.svg?token=Z5L0RYOVEZ)](https://codecov.io/gh/uw-ssec/offshore-geodesy)
 [![Documentation Status](https://readthedocs.org/projects/gnatss/badge/?version=latest)](https://gnatss.readthedocs.io/en/latest/?badge=latest)
 <br>


### PR DESCRIPTION
## Overview

This PR changes the CI name from `Test` to `CI`, adds a pytest annotation capability and update README to reflect change.