### PR TITLE
ci: add noxfile to use nox for ease of development

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import nox
+
+DIR = Path(__file__).parent.resolve()
+
+nox.options.sessions = ["lint", "tests"]
+
+
+@nox.session
+def lint(session: nox.Session) -> None:
+    """
+    Run the linter.
+    """
+    session.install("pre-commit")
+    session.run(
+        "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs
+    )
+
+
+@nox.session
+def tests(session: nox.Session) -> None:
+    """
+    Run the unit and regular tests.
+    """
+    session.install(".[test]")
+    session.run("pytest", "-vvv", "tests", *session.posargs)
+
+
+@nox.session
+def build(session: nox.Session) -> None:
+    """
+    Build an SDist and wheel.
+    """
+
+    build_path = DIR / "dist"
+    if build_path.exists():
+        shutil.rmtree(build_path)
+
+    session.install("build")
+    session.run("python", "-m", "build")


### PR DESCRIPTION
## Overview

This PR adds the use of [`nox`](https://nox.thea.codes/en/stable/) for ease of development by creating a `noxfile.py` configuration.