### PR TITLE
feat: Add feature to export and use outliers

### DIFF
--- a/src/gnatss/configs/io.py
+++ b/src/gnatss/configs/io.py
@@ -1,9 +1,24 @@
+from enum import Enum
 from typing import Any, Dict
 
 import fsspec
 from pydantic import BaseModel, Field, PrivateAttr
 
 from ..utilities.io import check_file_exists, check_permission
+
+
+class StrEnum(str, Enum):
+    """A custom string enum class"""
+
+    ...
+
+
+class CSVOutput(StrEnum):
+    """Default CSV output file names"""
+
+    outliers = "outliers.csv"
+    residuals = "residuals.csv"
+    dist_center = "dist_center.csv"
 
 
 class InputData(BaseModel):

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -7,6 +7,7 @@ import yaml
 from pydantic import ValidationError
 
 from . import constants
+from .configs.io import CSVOutput
 from .configs.main import Configuration
 
 
@@ -224,7 +225,9 @@ def load_gps_solutions(
     return all_gps_solutions
 
 
-def load_deletions(file_path: str, time_scale="tt") -> pd.DataFrame:
+def load_deletions(
+    file_path: str, config: Configuration, time_scale="tt"
+) -> pd.DataFrame:
     """
     Loads the raw deletion text file into a pandas dataframe
 
@@ -232,6 +235,8 @@ def load_deletions(file_path: str, time_scale="tt") -> pd.DataFrame:
     ----------
     file_path : str
         Path to the deletion file to be loaded
+    config : Configuration
+        The configuration object
     time_scale : str
         The time scale of the datetime string input.
         Default is 'tt' for Terrestrial Time,
@@ -267,5 +272,21 @@ def load_deletions(file_path: str, time_scale="tt") -> pd.DataFrame:
     cut_df[constants.DEL_ENDTIME] = cut_df[constants.DEL_ENDTIME].apply(
         lambda row: AstroTime(row, scale=time_scale).unix_j2000
     )
+
+    # Try to find outliers.csv file if there is one run already
+    # this currently assumes that the file is in the output directory
+    output_path = Path(config.output.path)
+    outliers_csv = output_path / CSVOutput.outliers.value
+    if outliers_csv.exists():
+        import typer
+
+        typer.echo(f"Found {str(outliers_csv.absolute())} file. Including into cuts...")
+        outliers_df = pd.read_csv(outliers_csv)
+        outlier_cut = pd.DataFrame.from_records(
+            outliers_df[constants.TT_TIME].apply(lambda row: (row, row)).to_numpy(),
+            columns=cut_df.columns,
+        )
+        # Include the outlier cut into here
+        cut_df = pd.concat([cut_df, outlier_cut])
 
     return cut_df

--- a/src/gnatss/main.py
+++ b/src/gnatss/main.py
@@ -792,15 +792,19 @@ def main(
     if extract_dist_center:
         dist_center_df = extract_distance_from_center(all_observations, config)
         typer.echo("Filtering out data outside of distance limit...")
-        # Filter out data that is outside of the distance limit
+        # Extract distance limit
+        distance_limit = config.solver.distance_limit
+
+        # Extract the rows of observations with distances beyond the limit
+        filtered_rows = dist_center_df[
+            dist_center_df[constants.GPS_DISTANCE] > distance_limit
+        ][constants.garpos.ST]
+
+        # Filter out data based on the filtered rows and reset index
         all_observations = all_observations[
-            ~all_observations[constants.garpos.ST].isin(
-                dist_center_df[
-                    dist_center_df[constants.GPS_DISTANCE]
-                    > config.solver.distance_limit
-                ][constants.garpos.ST]
-            )
+            ~all_observations[constants.garpos.ST].isin(filtered_rows)
         ].reset_index(drop=True)
+
     all_epochs = all_observations[constants.garpos.ST].unique()
     process_data, _ = prepare_and_solve(all_observations, config)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_gather_files(mocker):
         for k in item_keys
     }
     config = mocker.patch("gnatss.configs.main.Configuration")
-    config.solver.input_files.dict.return_value = sample_dict
+    config.solver.input_files.model_dump.return_value = sample_dict
 
     # Perform test
     all_files_dict = gather_files(config)


### PR DESCRIPTION
## Overview

This PR contains features to figure out residual outliers based on the `residual_limit` value as distance from center outlier from the `distance_limit` value. Additionally those outliers are now removed from the overall data before solve happens. In the case of residual outliers, this will be exported to `outliers.csv` file in the output directory specified by the user. During the `load_deletions` step, this `outliers.csv` file will be searched in the output directory, if it exists, then it will be included to the rest of the routine be removing those data from the input data for the solver routine.

This functionality mirrors:

```csh
proc_dist_del.csh           dist_center  $dist_limit
proc_outlier_del.csh                            {$label}_{$i}_{$j}_{$k}_{$l} $residual_limit
```

Closes #139 
Closes #140