### PR TITLE
feat: Add flags to override 'residual' and 'distance'

### DIFF
--- a/src/gnatss/cli.py
+++ b/src/gnatss/cli.py
@@ -5,8 +5,12 @@ from typing import Optional
 import typer
 
 from . import package_name
+from .configs.solver import Solver
 from .loaders import load_configuration
 from .main import gather_files, main
+
+# Global variables
+OVERRIDE_MESSAGE = "Note that this will override the value set as configuration."
 
 app = typer.Typer(name=package_name)
 
@@ -33,6 +37,20 @@ def run(
     extract_process_dataset: Optional[bool] = typer.Option(
         False, help="Flag to extract process results."
     ),
+    distance_limit: Optional[float] = typer.Option(
+        None,
+        help=(
+            f"{Solver.model_fields.get('distance_limit').description}"
+            f". {OVERRIDE_MESSAGE}"
+        ),
+    ),
+    residual_limit: Optional[float] = typer.Option(
+        None,
+        help=(
+            f"{Solver.model_fields.get('residual_limit').description}"
+            f". {OVERRIDE_MESSAGE}"
+        ),
+    ),
 ) -> None:
     """Runs the full pre-processing routine for GNSS-A
 
@@ -40,6 +58,15 @@ def run(
     """
     typer.echo("Loading configuration ...")
     config = load_configuration(config_yaml)
+
+    # Override the distance and residual limits if provided
+    # this short-circuits pydantic model
+    if distance_limit is not None:
+        config.solver.distance_limit = distance_limit
+
+    if residual_limit is not None:
+        config.solver.residual_limit = residual_limit
+
     typer.echo("Configuration loaded.")
     all_files_dict = gather_files(config)
 


### PR DESCRIPTION
Added optional CLI flags '--distance-limit' and '--residual-limit' to short-circuit any pydantic way to set those values such as environment variables or the values in config yaml.

--------

Ref: Issue #142 