### PR TITLE
feat: Add input for outlier threshold

### DIFF
--- a/src/gnatss/cli.py
+++ b/src/gnatss/cli.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import typer
 
-from . import package_name
+from . import constants, package_name
 from .configs.io import CSVOutput
 from .configs.solver import Solver
 from .loaders import load_configuration
@@ -36,7 +36,7 @@ def run(
         False, help="Flag to extract process results."
     ),
     outlier_threshold: Optional[float] = typer.Option(
-        25.0,
+        constants.DATA_OUTLIER_THRESHOLD,
         help=(
             "Threshold for allowable percentage of outliers "
             "before raising a runtime error."

--- a/src/gnatss/cli.py
+++ b/src/gnatss/cli.py
@@ -35,6 +35,13 @@ def run(
     extract_process_dataset: Optional[bool] = typer.Option(
         False, help="Flag to extract process results."
     ),
+    outlier_threshold: Optional[float] = typer.Option(
+        25.0,
+        help=(
+            "Threshold for allowable percentage of outliers "
+            "before raising a runtime error."
+        ),
+    ),
     distance_limit: Optional[float] = typer.Option(
         None,
         help=(
@@ -74,6 +81,7 @@ def run(
         config,
         all_files_dict,
         extract_process_dataset=extract_process_dataset,
+        outlier_threshold=outlier_threshold,
     )
 
     # TODO: Switch to fsspec so we can save anywhere

--- a/src/gnatss/configs/solver.py
+++ b/src/gnatss/configs/solver.py
@@ -160,7 +160,7 @@ class Solver(BaseModel):
         ),
     )
     residual_limit: float = Field(
-        50.0,
+        10000.0,
         ge=0.0,
         description=(
             "Maximum residual in centimeters beyond "

--- a/src/gnatss/constants/__init__.py
+++ b/src/gnatss/constants/__init__.py
@@ -9,6 +9,7 @@ __all__ = ["garpos"]
 # General constants
 SIG_3D = "sig_3d"
 DELAY_TIME_PRECISION = 6
+DATA_OUTLIER_THRESHOLD = 25.0
 
 # Data columns for sound profile
 SP_DEPTH = "depth"

--- a/src/gnatss/main.py
+++ b/src/gnatss/main.py
@@ -754,7 +754,7 @@ def main(
     config: Configuration,
     all_files_dict: Dict[str, Any],
     extract_process_dataset: bool = False,
-    outlier_threshold: float = 25.0,
+    outlier_threshold: float = constants.DATA_OUTLIER_THRESHOLD,
 ) -> Tuple[
     List[float],
     Dict[str, Any],

--- a/src/gnatss/main.py
+++ b/src/gnatss/main.py
@@ -831,7 +831,7 @@ def main(
         message += "Please re-run the program again to remove these outliers.\n"
         if percent_outliers > outlier_threshold:
             raise RuntimeError(
-                "The number of outliers is greater than the threshold of "
+                f"The number of outliers ({percent_outliers}%) is greater than the threshold of "
                 f"{outlier_threshold}%. Please check your residual limit"
             )
 

--- a/src/gnatss/main.py
+++ b/src/gnatss/main.py
@@ -754,6 +754,7 @@ def main(
     config: Configuration,
     all_files_dict: Dict[str, Any],
     extract_process_dataset: bool = False,
+    outlier_threshold: float = 25.0,
 ) -> Tuple[
     List[float],
     Dict[str, Any],
@@ -823,11 +824,18 @@ def main(
 
     # Print out the number of outliers detected
     n_outliers = len(outliers_df)
-    message = f"There are {n_outliers} outliers found during this run. "
+    percent_outliers = np.round((n_outliers / all_epochs.size) * 100.0, 2)
+    message = f"There are {n_outliers} outliers found during this run.\n"
     if n_outliers > 0:
-        message += "Please modify your residual limit."
+        message += f"This is {percent_outliers}% of the total number of data points.\n"
+        message += "Please re-run the program again to remove these outliers.\n"
+        if percent_outliers > outlier_threshold:
+            raise RuntimeError(
+                "The number of outliers is greater than the threshold of "
+                f"{outlier_threshold}%. Please check your residual limit"
+            )
 
-    typer.echo(message + "\n")
+    typer.echo(message)
 
     # Extracts process dataset when specified
     process_ds = None


### PR DESCRIPTION
## Overview

This PR adds input for outlier threshold, so that a `RuntimeError` can be raised when outliers exceed the number of data. Additionally, modified the original residual limit to 10000.0

---

Ref: #170 