### PR TITLE
feat: Add numba harmonic mean implementation

### DIFF
--- a/src/gnatss/harmonic_mean.py
+++ b/src/gnatss/harmonic_mean.py
@@ -1,5 +1,10 @@
+from typing import Literal
+
+import numba
+import numpy as np
 import pandas as pd
 import scipy.stats
+from nptyping import Float64, NDArray, Shape
 
 from .constants import SP_DEPTH, SP_SOUND_SPEED
 
@@ -29,11 +34,7 @@ def _compute_hm(svdf: pd.DataFrame, start_depth: float, end_depth: float) -> flo
     end_depth : float
         The end depth for calculation
 
-    """  # noqa
-    for col in [SP_DEPTH, SP_SOUND_SPEED]:
-        if col not in svdf.columns:
-            raise ValueError(f"{col} column must exist in the input dataframe!")
-
+    """  # noqa: E501
     filtdf = svdf[
         (svdf[SP_DEPTH].round() >= start_depth) & (svdf[SP_DEPTH].round() <= end_depth)
     ]
@@ -44,7 +45,77 @@ def _compute_hm(svdf: pd.DataFrame, start_depth: float, end_depth: float) -> flo
     return scipy.stats.hmean(filtdf[SP_SOUND_SPEED], weights=weights, nan_policy="omit")
 
 
-def sv_harmonic_mean(svdf: pd.DataFrame, start_depth: float, end_depth: float) -> float:
+@numba.njit
+def _sv_harmon_mean(
+    dd: NDArray[Shape["*"], Float64],
+    sv: NDArray[Shape["*"], Float64],
+    zs: float,
+    ze: float,
+) -> float:
+    """
+    Compute harmonic mean of sound speed profile using algorithm from
+    the original fortran implementation.
+
+    Parameters
+    ----------
+    dd : (N,) ndarray
+        The depth data.
+        Values must be negative downward.
+    sv : (N,) ndarray
+        The sound speed data.
+        Values must be positive.
+    zs : float
+        The start depth for harmonic mean to be computed
+    ze : float
+        The end depth for harmonic mean to be computed
+
+    Returns
+    -------
+    float
+        The sound speed harmonic mean result
+    """
+    # Ensure that depth and sound speed arrays
+    # are the same shape
+    assert dd.shape == sv.shape
+
+    zi = zs
+    sum = 0.0
+
+    for i in range(0, dd.shape[0]):
+        z1, c_z1 = dd[i], sv[i]
+        z2, c_z2 = dd[i + 1], sv[i + 1]
+
+        if i > 0:
+            zi = z1
+        if z1 <= ze:
+            break
+
+        zf = z2
+        if z2 < ze:
+            zf = ze
+
+        # Compute slope
+        b = (c_z2 - c_z1) / (z2 - z1)
+
+        # Ensure that slope is not 0
+        assert b != 0.0
+
+        # Compute the weight
+        wi = np.log((zi - z1) * b + c_z1) / b
+        wf = np.log((zf - z1) * b + c_z1) / b
+        w_d = wf - wi
+        sum += w_d
+    svhm = (ze - zs) / sum
+
+    return svhm
+
+
+def sv_harmonic_mean(
+    svdf: pd.DataFrame,
+    start_depth: float,
+    end_depth: float,
+    method: Literal["scipy", "numba"] = "numba",
+) -> float:
     """
     Computes harmonic mean from a sound profile
     containing depth (dd) and sound speed (sv)
@@ -57,6 +128,13 @@ def sv_harmonic_mean(svdf: pd.DataFrame, start_depth: float, end_depth: float) -
         The start depth for harmonic mean to be computed
     end_depth : int or float
         The end depth for harmonic mean to be computed
+    method : {"scipy", "numba"}, default "numba"
+        The method to use for computing the harmonic mean.
+        The options are "scipy" and "numba".
+
+        "scipy" uses scipy.stats.hmean method.
+        "numba" uses numba.njit method and it's an equivalent algorithm,
+        to the original fortran implementation.
 
     Returns
     -------
@@ -67,9 +145,33 @@ def sv_harmonic_mean(svdf: pd.DataFrame, start_depth: float, end_depth: float) -
         raise ValueError("Dataframe is empty! Please check your data inputs.")
     # Clean up the sound speed value, ensuring that there's no negative value
     svdf = svdf[svdf[SP_SOUND_SPEED] > 0].reset_index(drop=True)
-    # Make all of the values absolute values, so we're only dealing with positives
-    abs_start = abs(start_depth)
-    abs_end = abs(end_depth)
-    abs_sv = abs(svdf)
 
-    return _compute_hm(abs_sv, abs_start, abs_end)
+    for col in [SP_DEPTH, SP_SOUND_SPEED]:
+        if col not in svdf.columns:
+            raise ValueError(f"{col} column must exist in the input dataframe!")
+
+    if method == "scipy":
+        # Make all of the values absolute values, so we're only dealing with positives
+        abs_start = abs(start_depth)
+        abs_end = abs(end_depth)
+        abs_sv = abs(svdf)
+
+        svhm = _compute_hm(abs_sv, abs_start, abs_end)
+    elif method == "numba":
+        # Ensure both start and end depths are negative
+        start_depth = -np.abs(start_depth)
+        end_depth = -np.abs(end_depth)
+
+        if start_depth < end_depth:
+            raise ValueError("Start depth must be greater than end depth!")
+
+        svdf = svdf[(svdf[SP_DEPTH].round() <= start_depth)]
+        # Extract the numpy arrays for depth and sound speed
+        # Make sure that the depth array has negative values
+        # and the sound speed array has positive values
+        dd = -np.abs(svdf[SP_DEPTH].values)
+        sv = np.abs(svdf[SP_SOUND_SPEED].values)
+
+        svhm = _sv_harmon_mean(dd, sv, start_depth, end_depth)
+
+    return svhm

--- a/src/gnatss/harmonic_mean.py
+++ b/src/gnatss/harmonic_mean.py
@@ -173,5 +173,7 @@ def sv_harmonic_mean(
         sv = np.abs(svdf[SP_SOUND_SPEED].values)
 
         svhm = _sv_harmon_mean(dd, sv, start_depth, end_depth)
+    else:
+        raise NotImplementedError(f"Method {method} is not implemented!")
 
     return svhm

--- a/src/gnatss/harmonic_mean.py
+++ b/src/gnatss/harmonic_mean.py
@@ -76,7 +76,9 @@ def _sv_harmon_mean(
     """
     # Ensure that depth and sound speed arrays
     # are the same shape
-    assert dd.shape == sv.shape, f"dd and sv should have the same shape. dd:{dd.shape} != sv:{sv.shape}"
+    assert (
+        dd.shape == sv.shape
+    ), f"dd and sv should have the same shape. dd:{dd.shape} != sv:{sv.shape}"
 
     zi = zs
     sum = 0.0
@@ -149,7 +151,7 @@ def sv_harmonic_mean(
     for col in [SP_DEPTH, SP_SOUND_SPEED]:
         if col not in svdf.columns:
             raise ValueError(f"{col} column must exist in the input dataframe!")
-    
+
     # lower the strings to normalize input
     method = method.lower()
     if method == "scipy":
@@ -165,7 +167,9 @@ def sv_harmonic_mean(
         end_depth = -np.abs(end_depth)
 
         if start_depth < end_depth:
-            raise ValueError(f"Start depth {start_depth} must be greater than end depth {end_depth}!")
+            raise ValueError(
+                f"Start depth {start_depth} must be greater than end depth {end_depth}!"
+            )
 
         svdf = svdf[(svdf[SP_DEPTH].round() <= start_depth)]
         # Extract the numpy arrays for depth and sound speed

--- a/src/gnatss/harmonic_mean.py
+++ b/src/gnatss/harmonic_mean.py
@@ -76,7 +76,7 @@ def _sv_harmon_mean(
     """
     # Ensure that depth and sound speed arrays
     # are the same shape
-    assert dd.shape == sv.shape
+    assert dd.shape == sv.shape, f"dd and sv should have the same shape. dd:{dd.shape} != sv:{sv.shape}"
 
     zi = zs
     sum = 0.0
@@ -98,7 +98,7 @@ def _sv_harmon_mean(
         b = (c_z2 - c_z1) / (z2 - z1)
 
         # Ensure that slope is not 0
-        assert b != 0.0
+        assert b != 0.0, "Slope is zero"
 
         # Compute the weight
         wi = np.log((zi - z1) * b + c_z1) / b
@@ -149,7 +149,9 @@ def sv_harmonic_mean(
     for col in [SP_DEPTH, SP_SOUND_SPEED]:
         if col not in svdf.columns:
             raise ValueError(f"{col} column must exist in the input dataframe!")
-
+    
+    # lower the strings to normalize input
+    method = method.lower()
     if method == "scipy":
         # Make all of the values absolute values, so we're only dealing with positives
         abs_start = abs(start_depth)
@@ -163,7 +165,7 @@ def sv_harmonic_mean(
         end_depth = -np.abs(end_depth)
 
         if start_depth < end_depth:
-            raise ValueError("Start depth must be greater than end depth!")
+            raise ValueError(f"Start depth {start_depth} must be greater than end depth {end_depth}!")
 
         svdf = svdf[(svdf[SP_DEPTH].round() <= start_depth)]
         # Extract the numpy arrays for depth and sound speed

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -75,7 +75,7 @@ def test__compute_hm_missing_columns():
     svdf = pd.DataFrame({"random_column1": [1, 2, 3], "random_column2": [4, 5, 6]})
     start_depth = 0
     end_depth = 2
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         _compute_hm(svdf, start_depth, end_depth)
 
 

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from gnatss.constants import SP_DEPTH, SP_SOUND_SPEED
-from gnatss.harmonic_mean import _compute_hm, sv_harmonic_mean
+from gnatss.harmonic_mean import _compute_hm, _sv_harmon_mean, sv_harmonic_mean
 
 from . import TEST_DATA_FOLDER
 
@@ -86,3 +86,16 @@ def test_sv_harmonic_mean_empty_dataframe():
     end_depth = 2
     with pytest.raises(ValueError):
         sv_harmonic_mean(svdf, start_depth, end_depth)
+
+
+# Add test for _sv_harmon_mean
+def test__sv_harmon_mean():
+    dd = np.array([-10, -20, -30, -40, -50])
+    sv = np.array([1500, 1490, 1480, 1470, 1460])
+    zs = -10
+    ze = -50
+
+    result = _sv_harmon_mean(dd, sv, zs, ze)
+    expected_result = 1480.0
+
+    assert np.round(result) == expected_result

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -38,6 +38,16 @@ def test_sv_harmonic_mean_fortran(end_depth, expected_hm, sound_profile_data):
     assert harmonic_mean == expected_hm
 
 
+def test_not_implemented(sound_profile_data):
+    svdf = sound_profile_data
+
+    start_depth = -4
+    end_depth = -1176.5866
+
+    with pytest.raises(NotImplementedError):
+        sv_harmonic_mean(svdf, start_depth, end_depth, "not_implemented")
+
+
 @pytest.mark.parametrize(
     "start_idx,end_idx,expected_hm",
     [(0, 3, 1501.535), (0, 6, 1501.07), (2, 5, 1500.915), (4, 7, 1500.295)],

--- a/tests/test_harmonic_mean.py
+++ b/tests/test_harmonic_mean.py
@@ -18,7 +18,19 @@ def sound_profile_data() -> pd.DataFrame:
     "end_depth,expected_hm",
     [(-1176.5866, 1481.542), (-1146.5881, 1481.513), (-1133.7305, 1481.5)],
 )
-def test_sv_harmonic_mean(end_depth, expected_hm, sound_profile_data):
+def test_sv_harmonic_mean_scipy(end_depth, expected_hm, sound_profile_data):
+    svdf = sound_profile_data
+    start_depth = -4
+    harmonic_mean = round(sv_harmonic_mean(svdf, start_depth, end_depth, "scipy"), 3)
+
+    assert harmonic_mean == expected_hm
+
+
+@pytest.mark.parametrize(
+    "end_depth,expected_hm",
+    [(-1176.5866, 1481.551), (-1146.5881, 1481.521), (-1133.7305, 1481.509)],
+)
+def test_sv_harmonic_mean_fortran(end_depth, expected_hm, sound_profile_data):
     svdf = sound_profile_data
     start_depth = -4
     harmonic_mean = round(sv_harmonic_mean(svdf, start_depth, end_depth), 3)


### PR DESCRIPTION
Added '_sv_harmon_mean' numba implementation for
calculating harmonic mean that uses calculations
used within the original fortran code to get same
harmonic values. Now there's a 'method' value for the main 'sv_harmonic_mean' function that allows user
to switch back and forth b/w the two methods.

---

Ref #193